### PR TITLE
updated schema to include l for link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ draft*.xml
 .i-d-template
 old
 old?
+ex*.chk
+ex*.Z
+

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION = 02
 
 draft: txt html 
 
-all: draft check check2  $(DRAFT).diff.html ex1.gen.exi.hex ex1.gen.xml ex1.json ex10.json ex11.json  ex2.gen.exi.hex ex2.gen.xml ex2.json ex3.json ex4.gen.json-trim ex5.json ex6.json senml.gen.xsd senml.rnc ex8.json ex3.gen.xml ex3.gen.cbor.hex size.md ex3.gen.cbor.txt
+all: draft check check2  $(DRAFT).diff.html ex1.gen.exi.hex ex1.gen.xml ex1.json ex10.json ex11.json  ex2.gen.exi.hex ex2.gen.xml ex2.json ex3.json ex4.gen.json-trim ex5.json ex6.json senml.gen.xsd senml.rnc ex8.json ex3.gen.xml ex3.gen.cbor.hex size.md ex3.gen.cbor.txt ex3.gen.cbor ex8.gen.xml
 
 check: ex11.gen.chk ex10.gen.chk  ex8.gen.chk ex6.gen.chk ex5.gen.chk ex4.gen.chk ex3.gen.chk ex2.gen.chk ex1.gen.chk
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ kramdown-rfc2629 ?= kramdown-rfc2629
 
 
 DRAFT = draft-ietf-core-senml
-VERSION = 02
+VERSION = 03
 
 .PHONY: draft txt html pdf  clean check check2
 

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -533,6 +533,7 @@ only an unsigned integer is allowed.
 | Time                      | t          |          6 |
 | Update Time               | ut         |          7 |
 | Data Value                | vd         |          8 |
+| Link                      | l       |          9 |
 {: #tbl-cbor-labels cols="r l r" title="CBOR representation: integers for map keys"}
 
 The following example shows a dump of the CBOR example for the same sensor
@@ -1109,12 +1110,12 @@ for their review comments.
 
 # Links extension
 
-An extension to SenML to support links is expected to be registered and
-defined by {{I-D.ietf-core-links-json}}.
+An atribute to support an link extension for SenML is defined as a string
+attribute by this specification. The link extension can be used for additional
+information.  The definition and usage of the contents of this value are
+specified in {{I-D.ietf-core-links-json}}.
 
-The link extension can be an array of objects that can be used for
-additional information. Each object in the Link array is constrained to
-being a map of strings to strings with unique keys. 
+For JSON and XML the attribtue has a label of "l" and a value that is a string.
 
 The following shows an example of the links extension.
 

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -351,11 +351,19 @@ Representing the statistical characteristics of measurements, such as accuracy,
 can be very complex. Future specification may add new attributes to provide
 better information about the statistical properties of the measurement.
 
+## Expanded Records
+
+Sometimes it is useful to be able to refer to a defined normalized format for
+SenML records is useful for big data applications and intermediate forms. 
+
 A SenML Record is referred to as "expanded" if it does not contain any base
-values and has no relative times, but the the base values of the SenML Pack
-(if any) are applied to the Record. That is, name and base name are
-concatenated, base time is added to the time of the Record, if Record did 
-not contain Unit the Base Unit is applied to the record, etc.
+values and has no relative times, but the the base values of the SenML Pack (if
+any) are applied to the Record. That is, name and base name are concatenated,
+base time is added to the time of the Record, if Record did not contain Unit the
+Base Unit is applied to the record, etc. In addition, for XML and JSON formats, each
+record is on one line with no extra whitespace.
+
+TODO add example
 
 ## Associating Meta-data
 

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -260,7 +260,10 @@ Base Unit:
     
 Base Value:
 : A base value is added to the value found in an entry, similar to Base Time. 
-
+ 
+Base Sum:
+: A base sum is added to the sum found in an entry, similar to Base Time. 
+ 
 Version:
 : Version number of media type format. This attribute is an optional positive
   integer and defaults to 5 if not present. \[RFC Editor: change
@@ -379,6 +382,7 @@ used in JSON SenML Record attributes.
 | Base Time     | bt   | Number         |
 | Base Unit     | bu   | String         |
 | Base Value    | bv   | Number         |
+| Base Sum    | bs   | Number         |
 | Version       | bver | Number         |
 | Name          | n    | String         |
 | Unit          | u    | String         |
@@ -523,6 +527,7 @@ only an unsigned integer is allowed.
 | Base Time                 | bt         |         -3 |
 | Base Units                | bu         |         -4 |
 | Base Value                | bv         |         -5 |
+| Base Sum                | bs         |         -6 |
 | Name                      | n          |          0 |
 | Units                     | u          |          1 |
 | Value                     | v          |          2 |

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -1124,9 +1124,9 @@ for their review comments.
 
 # Links extension
 
-An atribute to support an link extension for SenML is defined as a string
+An attribute to support a link extension for SenML is defined as a string
 attribute by this specification. The link extension can be used for additional
-information.  The definition and usage of the contents of this value are
+information about a SenML Record.  The definition and usage of the contents of this value are
 specified in {{I-D.ietf-core-links-json}}.
 
 For JSON and XML the attribtue has a label of "l" and a value that is a string.

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -546,6 +546,7 @@ only an unsigned integer is allowed.
 | Time                      | t          |          6 |
 | Update Time               | ut         |          7 |
 | Data Value                | vd         |          8 |
+| Link                      | l       |          9 |
 {: #tbl-cbor-labels cols="r l r" title="CBOR representation: integers for map keys"}
 
 The following example shows a dump of the CBOR example for the same sensor
@@ -1123,12 +1124,12 @@ for their review comments.
 
 # Links extension
 
-An extension to SenML to support links is expected to be registered and
-defined by {{I-D.ietf-core-links-json}}.
+An atribute to support an link extension for SenML is defined as a string
+attribute by this specification. The link extension can be used for additional
+information.  The definition and usage of the contents of this value are
+specified in {{I-D.ietf-core-links-json}}.
 
-The link extension can be an array of objects that can be used for
-additional information. Each object in the Link array is constrained to
-being a map of strings to strings with unique keys. 
+For JSON and XML the attribtue has a label of "l" and a value that is a string.
 
 The following shows an example of the links extension.
 

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -360,7 +360,8 @@ A SenML Record is referred to as "expanded" if it does not contain any base
 values and has no relative times, but the the base values of the SenML Pack (if
 any) are applied to the Record. That is, name and base name are concatenated,
 base time is added to the time of the Record, if Record did not contain Unit the
-Base Unit is applied to the record, etc. In addition, for XML and JSON formats, each
+Base Unit is applied to the record, etc. In addition the records need to be in
+chronological order and for XML and JSON formats, each
 record is on one line with no extra whitespace.
 
 TODO add example

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -351,18 +351,18 @@ Representing the statistical characteristics of measurements, such as accuracy,
 can be very complex. Future specification may add new attributes to provide
 better information about the statistical properties of the measurement.
 
-## Expanded Records
+## Resolved Records
 
 Sometimes it is useful to be able to refer to a defined normalized format for
-SenML records is useful for big data applications and intermediate forms. 
+SenML records. This normalized format tends to get used for big data
+applications and intermediate forms when converting to other formats.
 
-A SenML Record is referred to as "expanded" if it does not contain any base
+A SenML Record is referred to as "resolved" if it does not contain any base
 values and has no relative times, but the the base values of the SenML Pack (if
 any) are applied to the Record. That is, name and base name are concatenated,
 base time is added to the time of the Record, if Record did not contain Unit the
 Base Unit is applied to the record, etc. In addition the records need to be in
-chronological order and for XML and JSON formats, each
-record is on one line with no extra whitespace.
+chronological order.
 
 TODO add example
 

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -567,6 +567,7 @@ attribute names and types used in the XML senml tags.
 | Base Time     | bt   | double  |
 | Base Unit     | bu   | string  |
 | Base Value    | bv   | double  |
+| Base Sum    | bs   | double  |
 | Base Version  | bver | int     |
 | Name          | n    | string  |
 | Unit          | u    | string  |

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -872,7 +872,7 @@ judgment but need to consider the following guidelines:
    Measure {{UCUM}}.
 
 
-## SenML label registry {#iana-senml-label-registry}
+## SenML Label Registry {#iana-senml-label-registry}
 
 IANA will create a new registry for SenML labels. The initial content of the
 registry are shown in {{tbl-json-labels}} and {{tbl-xml-labels}}.
@@ -1122,7 +1122,7 @@ for their review comments.
 
 --- back
 
-# Links extension
+# Links Extension
 
 An attribute to support a link extension for SenML is defined as a string
 attribute by this specification. The link extension can be used for additional

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -283,12 +283,11 @@ Unit:
 
 Value
 : Value of the entry.  Optional if a Sum value is present, otherwise
-  required. Values are represented using three basic data types, Floating point
-  numbers ("v" field for "Value"), Booleans ("vb" for "Boolean Value"),
-  Strings ("vs" for "String Value") and Binary Data ("vd" for "Data Value") .
-  Exactly one of these four fields MUST
-  appear unless there is Sum field in which case it is allowed to have no Value
-  field or to have "v" field. 
+  required. Values are represented using basic data types. This specification
+  defines floating point numbers ("v" field for "Value"), booleans ("vb" for 
+  "Boolean Value"), strings ("vs" for "String Value") and binary data ("vd" for
+  "Data Value"). Exactly one value field MUST appear unless there is Sum field 
+  in which case it is allowed to have no Value field. 
 
 Sum:
 : Integrated sum of the values over time. Optional. This attribute is in the

--- a/senml.gen.xsd
+++ b/senml.gen.xsd
@@ -10,6 +10,7 @@ xmlns:ns1="urn:ietf:params:xml:ns:senml">
       <xs:attribute name="bv" type="xs:double" />
       <xs:attribute name="bu" type="xs:string" />
       <xs:attribute name="bver" type="xs:int" />
+      <xs:attribute name="l" type="xs:string" />
       <xs:attribute name="n" type="xs:string" />
       <xs:attribute name="s" type="xs:double" />
       <xs:attribute name="t" type="xs:double" />

--- a/senml.rnc
+++ b/senml.rnc
@@ -9,6 +9,8 @@ senml = element senml {
   attribute bu { xsd:string }?,
   attribute bver { xsd:int }?,
 
+  attribute l { xsd:string }?,
+
   attribute n { xsd:string }?,
   attribute s { xsd:double }?,
   attribute t { xsd:double }?,

--- a/senml.rnc
+++ b/senml.rnc
@@ -6,6 +6,7 @@ senml = element senml {
   attribute bn { xsd:string }?,
   attribute bt { xsd:double }?,
   attribute bv { xsd:double }?,
+  attribute bs { xsd:double }?,
   attribute bu { xsd:string }?,
   attribute bver { xsd:int }?,
 

--- a/senml.rnc
+++ b/senml.rnc
@@ -10,6 +10,8 @@ senml = element senml {
   attribute bu { xsd:string }?,
   attribute bver { xsd:int }?,
 
+  attribute l { xsd:string }?,
+
   attribute n { xsd:string }?,
   attribute s { xsd:double }?,
   attribute t { xsd:double }?,


### PR DESCRIPTION
The link was missing from schema. After this is merged, all the example need to be regenerated. 
